### PR TITLE
Update app for live TV only

### DIFF
--- a/mobile-app/lib/view/components/bottom_Nav/bottom_nav.dart
+++ b/mobile-app/lib/view/components/bottom_Nav/bottom_nav.dart
@@ -40,40 +40,51 @@ class _CustomBottomNavState extends State<CustomBottomNav> {
         _onTap(index);
       },
       items: <BottomNavyBarItem>[
-        BottomNavyBarItem(icon: SvgPicture.asset(MyImages.homeIcon, height: 16, width: 16, color: widget.currentIndex == 0 ? MyColor.primaryColor : MyColor.colorWhite), title: Text(MyStrings.home.tr), activeColor: MyColor.primaryColor, textAlign: TextAlign.center, inactiveColor: MyColor.primaryText),
-        BottomNavyBarItem(icon: SvgPicture.asset(MyImages.allMovieIcon, height: 16, width: 16, color: widget.currentIndex == 1 ? MyColor.primaryColor : MyColor.colorWhite), title: Text(MyStrings.movie.tr), activeColor: MyColor.primaryColor, textAlign: TextAlign.center, inactiveColor: MyColor.primaryText),
-        BottomNavyBarItem(icon: SvgPicture.asset(MyImages.allTvSeriesIcon, height: 16, width: 16, color: widget.currentIndex == 2 ? MyColor.primaryColor : MyColor.colorWhite), title: Text(MyStrings.allSeries.tr), activeColor: MyColor.primaryColor, textAlign: TextAlign.center, inactiveColor: MyColor.primaryText),
-        BottomNavyBarItem(icon: Image.asset(MyImages.reelsImage, height: 16, width: 16, color: widget.currentIndex == 3 ? MyColor.primaryColor : MyColor.colorWhite), title: Text(MyStrings.reels.tr), activeColor: MyColor.primaryColor, textAlign: TextAlign.center, inactiveColor: MyColor.primaryText),
+        BottomNavyBarItem(
+            icon: SvgPicture.asset(MyImages.homeIcon,
+                height: 16,
+                width: 16,
+                color: widget.currentIndex == 0
+                    ? MyColor.primaryColor
+                    : MyColor.colorWhite),
+            title: Text(MyStrings.home.tr),
+            activeColor: MyColor.primaryColor,
+            textAlign: TextAlign.center,
+            inactiveColor: MyColor.primaryText),
         Get.find<ApiClient>().isAuthorizeUser()
-            ? BottomNavyBarItem(icon: SvgPicture.asset(MyImages.menuIcon, height: 16, width: 16, color: widget.currentIndex == 4 ? MyColor.primaryColor : MyColor.colorWhite), title: Text(MyStrings.menu.tr), activeColor: MyColor.primaryColor, textAlign: TextAlign.center, inactiveColor: MyColor.primaryText)
-            : BottomNavyBarItem(icon: const Icon(Icons.account_circle_rounded, color: MyColor.colorWhite), title: Text(MyStrings.login.tr), activeColor: MyColor.primaryColor, textAlign: TextAlign.center, inactiveColor: MyColor.primaryText),
+            ? BottomNavyBarItem(
+                icon: SvgPicture.asset(MyImages.menuIcon,
+                    height: 16,
+                    width: 16,
+                    color: widget.currentIndex == 1
+                        ? MyColor.primaryColor
+                        : MyColor.colorWhite),
+                title: Text(MyStrings.menu.tr),
+                activeColor: MyColor.primaryColor,
+                textAlign: TextAlign.center,
+                inactiveColor: MyColor.primaryText)
+            : BottomNavyBarItem(
+                icon: const Icon(Icons.account_circle_rounded,
+                    color: MyColor.colorWhite),
+                title: Text(MyStrings.login.tr),
+                activeColor: MyColor.primaryColor,
+                textAlign: TextAlign.center,
+                inactiveColor: MyColor.primaryText),
       ],
     );
   }
 
   void _onTap(int index) {
     if (index == 0) {
-      if (!(widget.currentIndex == 0)) {
+      if (widget.currentIndex != 0) {
         Get.offAllNamed(RouteHelper.homeScreen);
       }
     } else if (index == 1) {
-      if (!(widget.currentIndex == 1)) {
-        Get.offAllNamed(RouteHelper.allMovieScreen);
-      }
-    } else if (index == 2) {
-      if (!(widget.currentIndex == 2)) {
-        Get.offAllNamed(RouteHelper.allEpisodeScreen);
-      }
-    } else if (index == 3) {
-      if (!(widget.currentIndex == 3)) {
-        Get.offAllNamed(RouteHelper.reelsVideoScreen);
-      }
-    } else if (index == 4) {
       if (Get.find<ApiClient>().isAuthorizeUser()) {
-        printx('Tap $index');
         Scaffold.of(context).openDrawer();
+      } else {
+        Get.offAllNamed(RouteHelper.loginScreen);
       }
-      Get.find<ApiClient>().isAuthorizeUser() ? Scaffold.of(context).openDrawer() : Get.offAllNamed(RouteHelper.loginScreen);
     }
   }
 }

--- a/mobile-app/lib/view/components/nav_drawer/custom_nav_drawer.dart
+++ b/mobile-app/lib/view/components/nav_drawer/custom_nav_drawer.dart
@@ -111,38 +111,6 @@ class _NavigationDrawerWidgetState extends State<NavigationDrawerWidget> {
                           SizedBox(height: space),
                           buildMenuItem(
                             context,
-                            item: NavigationItem.myreelsScreen,
-                            text: MyStrings.myReels.tr,
-                            index: 22,
-                            icon: Icons.play_arrow_rounded,
-                            iconImage: MyImages.sideNameRentImage,
-                            isImage: true,
-                          ),
-                          SizedBox(height: space),
-                          buildMenuItem(
-                            context,
-                            item: NavigationItem.rentItemScreen,
-                            text: MyStrings.rentedItems.tr,
-                            index: 21,
-                            icon: Icons.play_arrow_rounded,
-                            iconImage: MyImages.sideNameRentImage,
-                            isImage: true,
-                          ),
-                          if (Get.find<ApiClient>().isWatchPartyEnable()) ...[
-                            SizedBox(height: space),
-                            buildMenuItem(
-                              context,
-                              item: NavigationItem.watchPartyHistoryScreen,
-                              text: MyStrings.watchParty,
-                              index: 5,
-                              icon: Icons.history,
-                              iconImage: MyImages.watchPartyImage,
-                              isImage: true,
-                            ),
-                          ],
-                          SizedBox(height: space),
-                          buildMenuItem(
-                            context,
                             item: NavigationItem.payment,
                             text: MyStrings.payment,
                             index: 6,
@@ -285,27 +253,6 @@ class _NavigationDrawerWidgetState extends State<NavigationDrawerWidget> {
       bool isOk = isAuthorized();
       if (isOk) {
         Get.toNamed(RouteHelper.changePasswordScreen);
-      } else {
-        showErrorSnackbar();
-      }
-    } else if (item == NavigationItem.watchPartyHistoryScreen) {
-      bool isOk = isAuthorized();
-      if (isOk) {
-        Get.toNamed(RouteHelper.watchPartyHistoryScreen);
-      } else {
-        showErrorSnackbar();
-      }
-    } else if (item == NavigationItem.rentItemScreen) {
-      bool isOk = isAuthorized();
-      if (isOk) {
-        Get.toNamed(RouteHelper.rentItemScreen);
-      } else {
-        showErrorSnackbar();
-      }
-    } else if (item == NavigationItem.myreelsScreen) {
-      bool isOk = isAuthorized();
-      if (isOk) {
-        Get.toNamed(RouteHelper.myreelsVideoScreen);
       } else {
         showErrorSnackbar();
       }

--- a/mobile-app/lib/view/screens/all_episode/all_episode_screen.dart
+++ b/mobile-app/lib/view/screens/all_episode/all_episode_screen.dart
@@ -96,7 +96,7 @@ class _AllEpisodeScreenState extends State<AllEpisodeScreen> {
                     ),
                   ],
                 ),
-                bottomNavigationBar: const CustomBottomNav(currentIndex: 2),
+                bottomNavigationBar: const CustomBottomNav(currentIndex: 0),
               ),
             ));
   }

--- a/mobile-app/lib/view/screens/auth/login/login.dart
+++ b/mobile-app/lib/view/screens/auth/login/login.dart
@@ -67,7 +67,7 @@ class _LoginScreenState extends State<LoginScreen> {
       child: Scaffold(
         extendBodyBehindAppBar: true,
         backgroundColor: Colors.transparent,
-        bottomNavigationBar: const CustomBottomNav(currentIndex: 4),
+        bottomNavigationBar: const CustomBottomNav(currentIndex: 1),
         body: GetBuilder<LoginController>(
           builder: (controller) => SizedBox(
             height: MediaQuery.of(context).size.height,

--- a/mobile-app/lib/view/screens/bottom_nav_pages/all_movies/all_movies_screen.dart
+++ b/mobile-app/lib/view/screens/bottom_nav_pages/all_movies/all_movies_screen.dart
@@ -92,7 +92,7 @@ class _AllMovieScreenState extends State<AllMovieScreen> {
                       ),
                   ],
                 ),
-                bottomNavigationBar: const CustomBottomNav(currentIndex: 1),
+                bottomNavigationBar: const CustomBottomNav(currentIndex: 0),
               ),
             ));
   }

--- a/mobile-app/lib/view/screens/bottom_nav_pages/home/home_screen.dart
+++ b/mobile-app/lib/view/screens/bottom_nav_pages/home/home_screen.dart
@@ -254,46 +254,6 @@ class _HomeScreenState extends State<HomeScreen> with AutomaticKeepAliveClientMi
                                   ),
                                 )
                               ],
-                              const DividerSection(),
-                              Semantics(child: const SingleBannerWidget()),
-                              const DividerSection(),
-                              ShowMoreText(isShowMoreVisible: false, headerText: MyStrings.featuredItem, press: () {}),
-                              const SizedBox(height: Dimensions.spaceBetweenCategory),
-                              const FeaturedMovieWidget(),
-                              const SizedBox(height: Dimensions.spaceBetweenCategory),
-                              const DividerSection(topSpace: 10),
-                              ShowMoreRowWidget(
-                                value: MyStrings.ourFreeZone,
-                                isShowMoreVisible: true,
-                                press: () {
-                                  Get.toNamed(RouteHelper.allFreeZoneScreen);
-                                },
-                              ),
-                              const SizedBox(height: Dimensions.spaceBetweenCategory),
-                              const FreeZoneWidget(),
-                              const DividerSection(),
-                              const SecondSingleBannerWidget(),
-                              if (controller.trailerMovieList.isNotEmpty) ...[
-                                Column(
-                                  children: [
-                                    const DividerSection(),
-                                    ShowMoreRowWidget(
-                                        value: MyStrings.latestTrailer, isShowMoreVisible: false, press: () {}),
-                                    const SizedBox(height: Dimensions.spaceBetweenCategory),
-                                    const LatestTrailerWidget(),
-                                  ],
-                                )
-                              ],
-                              const DividerSection(),
-                              ShowMoreText(
-                                isShowMoreVisible: false,
-                                headerText: MyStrings.latestSeries,
-                                press: () {
-                                  Get.toNamed(RouteHelper.allLiveTVScreen);
-                                },
-                              ),
-                              const SizedBox(height: Dimensions.spaceBetweenCategory),
-                              const LatestSeries(),
                             ],
                           ),
                         ),

--- a/mobile-app/lib/view/screens/reels_video/reels_video_screen.dart
+++ b/mobile-app/lib/view/screens/reels_video/reels_video_screen.dart
@@ -172,7 +172,7 @@ class _ReelsVideoScreenState extends State<ReelsVideoScreen> with WidgetsBinding
                           );
                         },
                       ),
-            bottomNavigationBar: const CustomBottomNav(currentIndex: 3),
+            bottomNavigationBar: const CustomBottomNav(currentIndex: 0),
           ),
         );
       },


### PR DESCRIPTION
## Summary
- simplify bottom navigation to only Home and Menu
- drop watch party, rent items and reels from drawer menu
- adjust login screen nav index
- remove movies and series navigation indices
- trim home screen to show only live TV sections

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c709e15dc8326ae7a8a6095e8510a